### PR TITLE
Revert bower away with nbgrader fork

### DIFF
--- a/base-notebook/requirements.txt
+++ b/base-notebook/requirements.txt
@@ -5,7 +5,7 @@ chart-studio==1.1
 dash==1.12
 ipywidgets==7.5
 fredapi==0.4.2
-https://github.com/IllumiDesk/nbgrader/archive/v0.6.2.zip
+https://github.com/IllumiDesk/nbgrader/archive/v0.6.3.zip
 jupyter-contrib-nbextensions==0.5
 jupyter-dash==0.2.1.post1
 jupyter_server_proxy==1.5.0


### PR DESCRIPTION
- Updates nbgrader fork from 0.6.2 to 0.6.3
- Reverts bower-away from nbgrader fork and readds static assets to source control
