### PR TITLE
Bump grader and jupyterlab versions

### DIFF
--- a/illumidesk-notebook/requirements.txt
+++ b/illumidesk-notebook/requirements.txt
@@ -1,3 +1,3 @@
-https://github.com/IllumiDesk/nbgrader/archive/v0.64.2.zip
+https://github.com/IllumiDesk/nbgrader/archive/v0.64.3.zip
 jupyter-server-proxy==1.5.0
-jupyterlab==2.2.4
+jupyterlab==2.2.8


### PR DESCRIPTION
- Bump illumidesk/nbgrader package version to v0.64.3
- Bump Jupyterlab to 2.2.8