### PR TITLE
Fixes Dockerfile to include base configuration within illumidesk-notebook image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ lint-install: ## install hadolint
 	@echo "Hadolint nstallation done!"
 	@$(HADOLINT) --version
 
-test: ## test images as running containers
+test: build-all ## test images as running containers
 	${VENV_BIN}/pytest -v
 
 venv: ## install hadolint create virtual environment

--- a/README.md
+++ b/README.md
@@ -22,6 +22,18 @@ make venv
 make build-all
 ```
 
+You can also override default tags and/or images using the `--build-args` flag to override the defaults assigned to the `BASE_IMAGE` and `TAG` arguments.
+
+For example:
+
+```bash
+docker build \
+  --build-arg BASE_IMAGE=jupyter/minimal-notebook \
+  --build-arg TAG=latest \
+  -t illumidesk/illumidesk-notebook \
+  illumidesk-notebook/.
+```
+
 3. Run:
 
 Running the image standalone is helpful for testing:
@@ -39,41 +51,6 @@ Then, navigate to `http://localhost:8888` to access your Jupyter Notebook server
 ```bash
 make test
 ```
-
-## Build Mechanism
-
-1. Build and tag the base image or all images at once. Use the `TAG` argument to add your custom tag. The `TAG` argument defaults to `latest` if not specified.
-
-Build all images:
-
-```bash
-make build-all
-```
-
-Build one image with custom tag:
-
-```bash
-make build/illumidesk-notebook TAG=mytag
-```
-
-
-1. (Optional) Change the base image based on one of the [`jupyter/docker-stacks`](https://github.com/jupyter/docker-stacks) images.
-
-```
-
-FROM jupyter/scipy-notebook:latest
-
-RUN ... do stuff
-
-USER root
-
-RUN fix-permissions "${HOME} \
- && fix-permissions "${CONDA_DIR}  # make sure you run fix-permissions after doing stuff
-
-USER "${NB_USER}"
-
-```
-
 ## Development and Testing
 
 1. Create your virtual environment and install dev-requirements:
@@ -84,19 +61,28 @@ make venv
 
 2. Check Dockerfiles and code formatting with linters:
 
-```base
+```bash
 make lint-all
 ```
 
 3. Run tests:
 
-```base
+The standard `make test` command ensures the image is built before running tests:
+
+```bash
 make test
+```
+
+You can skip the build step and run the tests directly:
+
+```bash
+pytest -v
 ```
 
 ## References
 
 These images are based on the `jupyter/docker-stacks` images. [Refer to their documentation](https://jupyter-docker-stacks.readthedocs.io/en/latest/) for the full set of configuration options.
+
 ## License
 
 MIT

--- a/illumidesk-notebook/Dockerfile
+++ b/illumidesk-notebook/Dockerfile
@@ -1,6 +1,9 @@
-FROM jupyter/base-notebook:aec555e49be6 as base
+ARG TAG=aec555e49be6
+ARG BASE_IMAGE=jupyter/scipy-notebook
 
-FROM jupyter/scipy-notebook:aec555e49be6
+FROM jupyter/base-notebook:$TAG AS base
+
+FROM $BASE_IMAGE:$TAG
 
 ARG NB_UID=1000
 ARG NB_GID=100

--- a/illumidesk-notebook/Dockerfile
+++ b/illumidesk-notebook/Dockerfile
@@ -1,3 +1,5 @@
+FROM jupyter/base-notebook:aec555e49be6 as base
+
 FROM jupyter/scipy-notebook:aec555e49be6
 
 ARG NB_UID=1000
@@ -6,8 +8,8 @@ ARG NB_GID=100
 # add group id since its not included by repo2docker but we need it
 # to run fix-permissions
 ENV NB_USER=jovyan
-ENV NB_UID=$NB_UID
-ENV NB_GID=$NB_GID
+ENV NB_UID="${NB_UID}"
+ENV NB_GID="${NB_GID}"
 ENV HOME="/home/${NB_USER}"
 
 USER root
@@ -19,6 +21,7 @@ RUN chmod a+rx /usr/local/bin/before-notebook.d/enable_extensions.sh
 # default config that loads/appends from the base config. this is usefule in case
 # we need to add other images that default to other paths, etc.
 RUN mkdir -p /etc/jupyter
+COPY --from=base /etc/jupyter/jupyter_notebook_config.py /etc/jupyter/jupyter_notebook_config_base.py
 COPY jupyter_notebook_config.py /etc/jupyter/
 COPY global_nbgrader_config.py /etc/jupyter/nbgrader_config.py
 


### PR DESCRIPTION
- Updates Dockerfile to copy `jupyter_notebook_config.py` from upstream `jupyter/base-notebook`
- Add optional build argument to set a custom base image
- Updates Readme