### PR TITLE
Add nbgitpuller as a dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,74 +2,15 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
-## 2.0.0 (2021-01-26)
+### [1.1.0](https://github.com/IllumiDesk/illumidesk/compare/v1.1.0...v1.2.0) (2021-01-26)
 
 
-### ⚠ BREAKING CHANGES
+* Adds the `nbgitpuller` dependency to base image.
 
-* this repo no longer manages specific dependencies but rather a setup to run workspaces with the IllumiDesk stack.
-
-### Features
-
-* Add grader notebook ([#29](https://github.com/IllumiDesk/docker-stacks/issues/29)) ([ff80791](https://github.com/IllumiDesk/docker-stacks/commit/ff8079148a6e96f2335a4e1e6734e70e98102632))
-* Add JRE and tests ([#7](https://github.com/IllumiDesk/docker-stacks/issues/7)) ([952db2d](https://github.com/IllumiDesk/docker-stacks/commit/952db2d4b16452c9317a7ff026b153c73371caaa))
-* Consolidate role-base images ([#21](https://github.com/IllumiDesk/docker-stacks/issues/21)) ([552ec6a](https://github.com/IllumiDesk/docker-stacks/commit/552ec6a36899c896dd200a515dc18aadc31fdaae))
-* Convert to template repo ([#37](https://github.com/IllumiDesk/docker-stacks/issues/37)) ([49c82a4](https://github.com/IllumiDesk/docker-stacks/commit/49c82a4a18dabac9426b897322296b968dd0780f))
-* Install Julia packages in base image with install.jl file ([#6](https://github.com/IllumiDesk/docker-stacks/issues/6)) ([e64e9a4](https://github.com/IllumiDesk/docker-stacks/commit/e64e9a4c8fbe0145d77f4a1bc479e92b590b7a15))
-* Update base image and configs ([#15](https://github.com/IllumiDesk/docker-stacks/issues/15)) ([8628f03](https://github.com/IllumiDesk/docker-stacks/commit/8628f03c677197a6f7d613d2dc701ff6c98c66d6))
-* Update Jupyter Notebook config with SameSite setting ([#39](https://github.com/IllumiDesk/docker-stacks/issues/39)) ([5c82c9f](https://github.com/IllumiDesk/docker-stacks/commit/5c82c9fba10101e04bdcf4db4976b5632a7b4e2a))
+### [1.1.0](https://github.com/IllumiDesk/illumidesk/compare/v1.0.1...v1.1.0) (2021-01-25)
 
 
-### Bug Fixes
-
-* Remove shell directive in build stage ([#4](https://github.com/IllumiDesk/docker-stacks/issues/4)) ([4bf7e27](https://github.com/IllumiDesk/docker-stacks/commit/4bf7e277d34b6dca9e3a4a2db34cb7a4494d70d5))
-* Update Dockerfile to copy base jupyter notebook config ([#42](https://github.com/IllumiDesk/docker-stacks/issues/42)) ([e59bbd5](https://github.com/IllumiDesk/docker-stacks/commit/e59bbd5bdb4106b05f81c0a5614b674eea276167))
-
-## 3.0.0 (2021-01-26)
-
-
-### ⚠ BREAKING CHANGES
-
-* this repo no longer manages specific dependencies but rather a setup to run workspaces with the IllumiDesk stack.
-
-### Features
-
-* Add grader notebook ([#29](https://github.com/IllumiDesk/illumidesk/issues/29)) ([ff80791](https://github.com/IllumiDesk/illumidesk/commit/ff8079148a6e96f2335a4e1e6734e70e98102632))
-* Add JRE and tests ([#7](https://github.com/IllumiDesk/illumidesk/issues/7)) ([952db2d](https://github.com/IllumiDesk/illumidesk/commit/952db2d4b16452c9317a7ff026b153c73371caaa))
-* Consolidate role-base images ([#21](https://github.com/IllumiDesk/illumidesk/issues/21)) ([552ec6a](https://github.com/IllumiDesk/illumidesk/commit/552ec6a36899c896dd200a515dc18aadc31fdaae))
-* Convert to template repo ([#37](https://github.com/IllumiDesk/illumidesk/issues/37)) ([49c82a4](https://github.com/IllumiDesk/illumidesk/commit/49c82a4a18dabac9426b897322296b968dd0780f))
-* Install Julia packages in base image with install.jl file ([#6](https://github.com/IllumiDesk/illumidesk/issues/6)) ([e64e9a4](https://github.com/IllumiDesk/illumidesk/commit/e64e9a4c8fbe0145d77f4a1bc479e92b590b7a15))
-* Update base image and configs ([#15](https://github.com/IllumiDesk/illumidesk/issues/15)) ([8628f03](https://github.com/IllumiDesk/illumidesk/commit/8628f03c677197a6f7d613d2dc701ff6c98c66d6))
-* Update Jupyter Notebook config with SameSite setting ([#39](https://github.com/IllumiDesk/illumidesk/issues/39)) ([5c82c9f](https://github.com/IllumiDesk/illumidesk/commit/5c82c9fba10101e04bdcf4db4976b5632a7b4e2a))
-
-
-### Bug Fixes
-
-* Remove shell directive in build stage ([#4](https://github.com/IllumiDesk/illumidesk/issues/4)) ([4bf7e27](https://github.com/IllumiDesk/illumidesk/commit/4bf7e277d34b6dca9e3a4a2db34cb7a4494d70d5))
-* Update Dockerfile to copy base jupyter notebook config ([#42](https://github.com/IllumiDesk/illumidesk/issues/42)) ([e59bbd5](https://github.com/IllumiDesk/illumidesk/commit/e59bbd5bdb4106b05f81c0a5614b674eea276167))
-
-## 2.0.0 (2021-01-26)
-
-
-### ⚠ BREAKING CHANGES
-
-* this repo no longer manages specific dependencies but rather a setup to run workspaces with the IllumiDesk stack.
-
-### Features
-
-* Add grader notebook ([#29](https://github.com/IllumiDesk/illumidesk/issues/29)) ([ff80791](https://github.com/IllumiDesk/illumidesk/commit/ff8079148a6e96f2335a4e1e6734e70e98102632))
-* Add JRE and tests ([#7](https://github.com/IllumiDesk/illumidesk/issues/7)) ([952db2d](https://github.com/IllumiDesk/illumidesk/commit/952db2d4b16452c9317a7ff026b153c73371caaa))
-* Consolidate role-base images ([#21](https://github.com/IllumiDesk/illumidesk/issues/21)) ([552ec6a](https://github.com/IllumiDesk/illumidesk/commit/552ec6a36899c896dd200a515dc18aadc31fdaae))
-* Convert to template repo ([#37](https://github.com/IllumiDesk/illumidesk/issues/37)) ([49c82a4](https://github.com/IllumiDesk/illumidesk/commit/49c82a4a18dabac9426b897322296b968dd0780f))
-* Install Julia packages in base image with install.jl file ([#6](https://github.com/IllumiDesk/illumidesk/issues/6)) ([e64e9a4](https://github.com/IllumiDesk/illumidesk/commit/e64e9a4c8fbe0145d77f4a1bc479e92b590b7a15))
-* Update base image and configs ([#15](https://github.com/IllumiDesk/illumidesk/issues/15)) ([8628f03](https://github.com/IllumiDesk/illumidesk/commit/8628f03c677197a6f7d613d2dc701ff6c98c66d6))
-* Update Jupyter Notebook config with SameSite setting ([#39](https://github.com/IllumiDesk/illumidesk/issues/39)) ([5c82c9f](https://github.com/IllumiDesk/illumidesk/commit/5c82c9fba10101e04bdcf4db4976b5632a7b4e2a))
-
-
-### Bug Fixes
-
-* Remove shell directive in build stage ([#4](https://github.com/IllumiDesk/illumidesk/issues/4)) ([4bf7e27](https://github.com/IllumiDesk/illumidesk/commit/4bf7e277d34b6dca9e3a4a2db34cb7a4494d70d5))
-* Update Dockerfile to copy base jupyter notebook config ([#42](https://github.com/IllumiDesk/illumidesk/issues/42)) ([e59bbd5](https://github.com/IllumiDesk/illumidesk/commit/e59bbd5bdb4106b05f81c0a5614b674eea276167))
+* Removes `repo2docker` builder from base image and replaces the base image with a standard docker image based on the upstream [jupyter docker-stacks images](https://github.com/jupyter/docker-stacks).
 
 ### [1.0.1](https://github.com/IllumiDesk/illumidesk/compare/v1.0.0...v1.0.1) (2020-10-25)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## 3.0.0 (2021-01-26)
+
+
+### ⚠ BREAKING CHANGES
+
+* this repo no longer manages specific dependencies but rather a setup to run workspaces with the IllumiDesk stack.
+
+### Features
+
+* Add grader notebook ([#29](https://github.com/IllumiDesk/illumidesk/issues/29)) ([ff80791](https://github.com/IllumiDesk/illumidesk/commit/ff8079148a6e96f2335a4e1e6734e70e98102632))
+* Add JRE and tests ([#7](https://github.com/IllumiDesk/illumidesk/issues/7)) ([952db2d](https://github.com/IllumiDesk/illumidesk/commit/952db2d4b16452c9317a7ff026b153c73371caaa))
+* Consolidate role-base images ([#21](https://github.com/IllumiDesk/illumidesk/issues/21)) ([552ec6a](https://github.com/IllumiDesk/illumidesk/commit/552ec6a36899c896dd200a515dc18aadc31fdaae))
+* Convert to template repo ([#37](https://github.com/IllumiDesk/illumidesk/issues/37)) ([49c82a4](https://github.com/IllumiDesk/illumidesk/commit/49c82a4a18dabac9426b897322296b968dd0780f))
+* Install Julia packages in base image with install.jl file ([#6](https://github.com/IllumiDesk/illumidesk/issues/6)) ([e64e9a4](https://github.com/IllumiDesk/illumidesk/commit/e64e9a4c8fbe0145d77f4a1bc479e92b590b7a15))
+* Update base image and configs ([#15](https://github.com/IllumiDesk/illumidesk/issues/15)) ([8628f03](https://github.com/IllumiDesk/illumidesk/commit/8628f03c677197a6f7d613d2dc701ff6c98c66d6))
+* Update Jupyter Notebook config with SameSite setting ([#39](https://github.com/IllumiDesk/illumidesk/issues/39)) ([5c82c9f](https://github.com/IllumiDesk/illumidesk/commit/5c82c9fba10101e04bdcf4db4976b5632a7b4e2a))
+
+
+### Bug Fixes
+
+* Remove shell directive in build stage ([#4](https://github.com/IllumiDesk/illumidesk/issues/4)) ([4bf7e27](https://github.com/IllumiDesk/illumidesk/commit/4bf7e277d34b6dca9e3a4a2db34cb7a4494d70d5))
+* Update Dockerfile to copy base jupyter notebook config ([#42](https://github.com/IllumiDesk/illumidesk/issues/42)) ([e59bbd5](https://github.com/IllumiDesk/illumidesk/commit/e59bbd5bdb4106b05f81c0a5614b674eea276167))
+
 ## 2.0.0 (2021-01-26)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## 2.0.0 (2021-01-26)
+
+
+### ⚠ BREAKING CHANGES
+
+* this repo no longer manages specific dependencies but rather a setup to run workspaces with the IllumiDesk stack.
+
+### Features
+
+* Add grader notebook ([#29](https://github.com/IllumiDesk/docker-stacks/issues/29)) ([ff80791](https://github.com/IllumiDesk/docker-stacks/commit/ff8079148a6e96f2335a4e1e6734e70e98102632))
+* Add JRE and tests ([#7](https://github.com/IllumiDesk/docker-stacks/issues/7)) ([952db2d](https://github.com/IllumiDesk/docker-stacks/commit/952db2d4b16452c9317a7ff026b153c73371caaa))
+* Consolidate role-base images ([#21](https://github.com/IllumiDesk/docker-stacks/issues/21)) ([552ec6a](https://github.com/IllumiDesk/docker-stacks/commit/552ec6a36899c896dd200a515dc18aadc31fdaae))
+* Convert to template repo ([#37](https://github.com/IllumiDesk/docker-stacks/issues/37)) ([49c82a4](https://github.com/IllumiDesk/docker-stacks/commit/49c82a4a18dabac9426b897322296b968dd0780f))
+* Install Julia packages in base image with install.jl file ([#6](https://github.com/IllumiDesk/docker-stacks/issues/6)) ([e64e9a4](https://github.com/IllumiDesk/docker-stacks/commit/e64e9a4c8fbe0145d77f4a1bc479e92b590b7a15))
+* Update base image and configs ([#15](https://github.com/IllumiDesk/docker-stacks/issues/15)) ([8628f03](https://github.com/IllumiDesk/docker-stacks/commit/8628f03c677197a6f7d613d2dc701ff6c98c66d6))
+* Update Jupyter Notebook config with SameSite setting ([#39](https://github.com/IllumiDesk/docker-stacks/issues/39)) ([5c82c9f](https://github.com/IllumiDesk/docker-stacks/commit/5c82c9fba10101e04bdcf4db4976b5632a7b4e2a))
+
+
+### Bug Fixes
+
+* Remove shell directive in build stage ([#4](https://github.com/IllumiDesk/docker-stacks/issues/4)) ([4bf7e27](https://github.com/IllumiDesk/docker-stacks/commit/4bf7e277d34b6dca9e3a4a2db34cb7a4494d70d5))
+* Update Dockerfile to copy base jupyter notebook config ([#42](https://github.com/IllumiDesk/docker-stacks/issues/42)) ([e59bbd5](https://github.com/IllumiDesk/docker-stacks/commit/e59bbd5bdb4106b05f81c0a5614b674eea276167))
+
 ## 3.0.0 (2021-01-26)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## 2.0.0 (2021-01-26)
+
+
+### ⚠ BREAKING CHANGES
+
+* this repo no longer manages specific dependencies but rather a setup to run workspaces with the IllumiDesk stack.
+
+### Features
+
+* Add grader notebook ([#29](https://github.com/IllumiDesk/illumidesk/issues/29)) ([ff80791](https://github.com/IllumiDesk/illumidesk/commit/ff8079148a6e96f2335a4e1e6734e70e98102632))
+* Add JRE and tests ([#7](https://github.com/IllumiDesk/illumidesk/issues/7)) ([952db2d](https://github.com/IllumiDesk/illumidesk/commit/952db2d4b16452c9317a7ff026b153c73371caaa))
+* Consolidate role-base images ([#21](https://github.com/IllumiDesk/illumidesk/issues/21)) ([552ec6a](https://github.com/IllumiDesk/illumidesk/commit/552ec6a36899c896dd200a515dc18aadc31fdaae))
+* Convert to template repo ([#37](https://github.com/IllumiDesk/illumidesk/issues/37)) ([49c82a4](https://github.com/IllumiDesk/illumidesk/commit/49c82a4a18dabac9426b897322296b968dd0780f))
+* Install Julia packages in base image with install.jl file ([#6](https://github.com/IllumiDesk/illumidesk/issues/6)) ([e64e9a4](https://github.com/IllumiDesk/illumidesk/commit/e64e9a4c8fbe0145d77f4a1bc479e92b590b7a15))
+* Update base image and configs ([#15](https://github.com/IllumiDesk/illumidesk/issues/15)) ([8628f03](https://github.com/IllumiDesk/illumidesk/commit/8628f03c677197a6f7d613d2dc701ff6c98c66d6))
+* Update Jupyter Notebook config with SameSite setting ([#39](https://github.com/IllumiDesk/illumidesk/issues/39)) ([5c82c9f](https://github.com/IllumiDesk/illumidesk/commit/5c82c9fba10101e04bdcf4db4976b5632a7b4e2a))
+
+
+### Bug Fixes
+
+* Remove shell directive in build stage ([#4](https://github.com/IllumiDesk/illumidesk/issues/4)) ([4bf7e27](https://github.com/IllumiDesk/illumidesk/commit/4bf7e277d34b6dca9e3a4a2db34cb7a4494d70d5))
+* Update Dockerfile to copy base jupyter notebook config ([#42](https://github.com/IllumiDesk/illumidesk/issues/42)) ([e59bbd5](https://github.com/IllumiDesk/illumidesk/commit/e59bbd5bdb4106b05f81c0a5614b674eea276167))
+
 ### [1.0.1](https://github.com/IllumiDesk/illumidesk/compare/v1.0.0...v1.0.1) (2020-10-25)
 
 * Adds `standard-version` to manage releases

--- a/illumidesk-notebook/requirements.txt
+++ b/illumidesk-notebook/requirements.txt
@@ -1,3 +1,4 @@
 https://github.com/IllumiDesk/nbgrader/archive/v0.64.3.zip
 jupyter-server-proxy==1.5.0
 jupyterlab==2.2.8
+nbgitpuller==0.9.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "illumidesk-docker-stacks",
-  "version": "3.0.0",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "illumidesk-docker-stacks",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "illumidesk-docker-stacks",
-  "version": "2.0.0",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "illumidesk-docker-stacks",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "illumidesk-docker-stacks",
-  "version": "2.0.0",
+  "version": "1.2.0",
   "description": "Template repo to manage IllumiDesk compatible workspaces.",
   "scripts": {
     "release": "standard-version"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "illumidesk-docker-stacks",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Template repo to manage IllumiDesk compatible workspaces.",
   "scripts": {
     "release": "standard-version"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "illumidesk-docker-stacks",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "Template repo to manage IllumiDesk compatible workspaces.",
   "scripts": {
     "release": "standard-version"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "illumidesk-docker-stacks",
-  "version": "3.0.0",
+  "version": "2.0.0",
   "description": "Template repo to manage IllumiDesk compatible workspaces.",
   "scripts": {
     "release": "standard-version"
@@ -9,7 +9,7 @@
   "homepage": "https://illumidesk.com/",
   "repository": {
     "type": "git",
-    "url": "https://github.com/IllumiDesk/illumidesk.git"
+    "url": "https://github.com/IllumiDesk/docker-stacks.git"
   },
   "license": "MIT",
   "devDependencies": {


### PR DESCRIPTION
- Adds the nbgitpuller package to the base workspace image.
- Allows users to git clone/fetch/merge content hosted in GitHub using LTI 1.1 / LTI 1.3 Assignment or Module links.
- Tagged as release version `1.2.0`