### PR TITLE
enable course list api

### DIFF
--- a/grader-notebook/Dockerfile
+++ b/grader-notebook/Dockerfile
@@ -9,7 +9,8 @@ ENV NB_GID=100
 
 # enable nbgrader's create assignment and formgrader extensions
 RUN jupyter nbextension enable --sys-prefix create_assignment/main \
- && jupyter serverextension enable --sys-prefix nbgrader.server_extensions.formgrader
+ && jupyter serverextension enable --sys-prefix nbgrader.server_extensions.formgrader \
+ && jupyter serverextension enable --sys-prefix nbgrader.server_extensions.course_list
 
 # disable the assignment extension, since graders don't need it
 RUN jupyter nbextension disable --sys-prefix assignment_list/main --section=tree


### PR DESCRIPTION
this PR enables course_list extension to allow the frontend to use /formgraders api