### PR TITLE
Fix extension order

### DIFF
--- a/grader-notebook/Dockerfile
+++ b/grader-notebook/Dockerfile
@@ -15,16 +15,15 @@ RUN jupyter nbextension enable --sys-prefix create_assignment/main \
 # disable the assignment extension, since graders don't need it
 RUN jupyter nbextension disable --sys-prefix assignment_list/main --section=tree
 
-# install and activate the async-nbgrader and formgradernext extensions
-RUN jupyter nbextension install --sys-prefix --py formgradernext --overwrite \
- && jupyter nbextension enable --sys-prefix --py formgradernext \
- && jupyter serverextension enable --sys-prefix --py formgradernext \
- && jupyter serverextension enable --sys-prefix --py async_nbgrader
-
 # install and activate the async-nbgrader extensions
 RUN jupyter nbextension install --sys-prefix --py async_nbgrader --overwrite \
  && jupyter nbextension enable --sys-prefix --py async_nbgrader \
  && jupyter serverextension enable --sys-prefix --py async_nbgrader
+
+# install and activate the formgrader extensions
+RUN jupyter nbextension install --symlink --sys-prefix --py formgradernext --overwrite \
+ && jupyter nbextension enable --sys-prefix --py formgradernext \
+ && jupyter serverextension enable --sys-prefix --py formgradernext
 
 # fix permissions as root
 USER root

--- a/illumidesk-notebook/Dockerfile
+++ b/illumidesk-notebook/Dockerfile
@@ -23,11 +23,6 @@ RUN jupyter nbextension install --symlink --sys-prefix --py nbgrader --overwrite
  && jupyter nbextension disable --sys-prefix --py nbgrader \
  && jupyter serverextension disable --sys-prefix --py nbgrader
 
-# install formgradernext and then disable all extensions by default
-RUN jupyter nbextension install --symlink --sys-prefix --py formgradernext --overwrite \
- && jupyter nbextension disable --sys-prefix --py formgradernext \
- && jupyter serverextension disable --sys-prefix --py formgradernext
-
 # everyone gets the nbgrader validate extension
 RUN jupyter nbextension enable --sys-prefix validate_assignment/main --section=notebook \
  && jupyter serverextension enable --sys-prefix nbgrader.server_extensions.validate_assignment


### PR DESCRIPTION
- Updates Dockerfiles to install and enable the async-nbgrader and formgradernext extensions in the correct order